### PR TITLE
Build static binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ DO_DOCKER_TAG_LATEST="$2"
 
 gobuild() {
 	MOD="$1"
-	go build -ldflags="$LDFLAGS" -o "dist/$MOD-$GOOS-$ARCHNAME$EXESUFFIX" "./$MOD"
+	CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o "dist/$MOD-$GOOS-$ARCHNAME$EXESUFFIX" "./$MOD"
 }
 
 buildfor() {

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ then
 	VERSION="dev"
 fi
 
-LDFLAGS="-X 'github.com/Doridian/wsvpn/shared.Version=${VERSION}'"
+LDFLAGS="-w -s -X 'github.com/Doridian/wsvpn/shared.Version=${VERSION}'"
 DO_DOCKER_PUSH="$1"
 DO_DOCKER_TAG_LATEST="$2"
 


### PR DESCRIPTION
Current build process creates dynamically linked binaries which fail to work in a container:

```console
podman run --rm -v "$(pwd)"/config:/config ghcr.io/doridian/wsvpn/server
{"msg":"exec container process (missing dynamic library?) `/server`: No such file or directory","level":"error","time":"2022-08-05T15:19:25.000486585Z"}
```