### PR TITLE
New wiki entries for usage

### DIFF
--- a/docs/wiki/Client autoconfiguration.md
+++ b/docs/wiki/Client autoconfiguration.md
@@ -1,0 +1,201 @@
+# Client autoconfiguration
+In most other VPN solutions out there you usually have:
+
+- A custom routing table, to allow users to connect to different networks, without rerouting all traffic through the VPN (saving precious latency & bandwith).
+- A custom DNS server on connection, to allow users access to private webpages and services on the network.
+
+This describes how to set up your client files to auto configure  IP routing and DNS on VPN connection.
+
+# Windows
+### Initial file structure
+
+Download the latest windows binary from https://github.com/Doridian/wsvpn/releases/ , then execute it to create a default client configuration file
+
+./wsvpn-windows-amd64.exe --print-default-config -mode client > client.yml
+
+After this, configure this `client.yml` file to connect to your server URL with your preffered auth method.
+
+Create a batch file, here called `connect.bat`, with the following:
+
+#### connect.bat
+```batch
+cd C:\wsvpn
+wsvpn-windows-amd64.exe -mode "client" -config "client.yml"
+```
+Then, execute it as administrator to stablish a fresh connection. 
+This should create a new `wintun.dll` file and a windows adapter that will dissapear on disconection, called `WaterWinTunInterface`.
+
+Do not close this connection, as we will need this adapter to appear on windows.
+
+You should end up with this directory structure:
+```
+├── wsvpnclient-windows
+    ├── wsvpn-windows-amd64.exe
+    ├── wintun.dll
+    ├── connect.bat
+    └── client.yml
+```
+
+### Creating a powershell script
+In order to configure routing & dns in windows, you must use powershell commands, ran as administrator.
+
+First, you need to get the ID windows gave to your new `WaterWinTunInterface` adapter.
+
+```powershell
+(Get-NetAdapter | Where-Object { $_.Name -eq "WaterWinTunInterface" }).InterfaceIndex
+```
+
+Then you can configure your routing table.
+
+In windows, your routing table can be seen by doing:
+```powershell
+route print
+```
+
+**Example:** your client wants access to your main LAN. Its network address is `192.168.1.0/24`.
+
+So you need to add an entry in his routing table, telling windows to ask all related to this `192.168.1.0/24` network to the VPN interface.
+
+```powershell
+route add 192.168.1.0 mask 255.255.255.0 192.168.3.1 IF $interfaceIndex
+```
+Notice I gave the IP `192.168.3.1` before the interface ID, this is the VPN's server IP, or as commonly known, the VPN's `gateway`. You can ask this IP for any other IP addresses.
+
+To automate all this process at the end, you will end up with this script:
+#### client.ps1
+```powershell
+$interfaceIndex = (Get-NetAdapter | Where-Object { $_.Name -eq "WaterWinTunInterface" }).InterfaceIndex
+
+route add 192.168.1.0 mask 255.255.255.0 192.168.3.1 IF $interfaceIndex
+```
+
+Now, what if your client wants to access all private domains in your network, for example, login.private.com, that is only known by `192.168.1.250`?
+
+You must tell windows to use your private DNS IP. In this example, `192.168.1.250`. It is as simple as adding this to your script:
+
+#### client.ps1
+```powershell
+$interfaceIndex = (Get-NetAdapter | Where-Object { $_.Name -eq "WaterWinTunInterface" }).InterfaceIndex
+
+route add 192.168.1.0 mask 255.255.255.0 192.168.3.1 IF $interfaceIndex
+
+Set-DnsClientServerAddress -InterfaceIndex $interfaceIndex -ServerAddresses 192.168.1.250
+```
+
+### Telling WSVPN to execute client.ps1
+Simply find these lines and edit them as follows in your `client.yml` file:
+
+```yaml
+scripts:
+  # These scripts get run as "args... operation subnet interface"
+  # Pass in an array, first argument is the executable, further arguments
+  # are used before WSVPN provided arguments
+  # Example: "./handler.sh up 192.168.3.2/24 tun0"
+  up: ["powershell.exe", "-ExecutionPolicy", "Bypass", "-File", "client.ps1"]
+  down: []
+```
+
+All done! everytime you run `connect.bat` as administrator, you will get access to your main LAN, and also your private DNS domains.
+
+## Final windows client directory structure
+```
+├── wsvpnclient-windows
+    ├── wsvpn-windows-amd64.exe
+    ├── wintun.dll
+    ├── connect.bat
+    ├── client.yml
+    └── client.ps1
+```
+
+# Linux
+It is way, way easier to acomplish a custom routing table & DNS on linux.
+
+### Initial file structure
+
+Download the latest linux binary from https://github.com/Doridian/wsvpn/releases/ , then execute it to create a default client configuration file
+
+./wsvpn-linux-amd64
+ --print-default-config -mode client > client.yml
+
+After this, configure this `client.yml` file to connect to your server URL with your preffered auth method.
+
+Create a bash file, here called `connect.sh`, with the following:
+
+#### connect.sh
+```batch
+wsvpn-linux-amd64 -mode "client" -config "client.yml"
+```
+Then, execute it as `root` to stablish a fresh connection. 
+This should create a new linux tap interface that will dissapear on disconection, called `vpn0` or whatever you configured in your `client.yml` file.
+
+Do not close this connection, as we will need this adapter to appear on linux.
+
+You should end up with this directory structure:
+```
+├── wsvpnclient-linux
+    ├── wsvpn-linux-amd64
+    ├── connect.sh
+    └── client.yml
+```
+### Creating a bash setup script
+Almost all linux distros come with the ip software stack.
+
+All you need to know is your interface name, in this case, `vpn0`.
+
+In linux, your routing table can be seen by doing:
+```powershell
+ip route
+```
+
+To configure your routing table to forward all `192.168.1.0/24` (aka your main LAN), you just do:
+
+```bash
+ip route add 192.168.1.0/24 via 192.168.3.1 dev vpn0
+```
+
+Then, to set your private DNS you must add it as the first entry in your `/etc/resolv.conf`:
+```bash
+sed -i '1i nameserver 192.168.1.250' /etc/resolv.conf
+```
+
+Your final up script would look like:
+
+#### client.sh
+```bash
+ip route add 192.168.1.0/24 via 192.168.3.1 dev vpn0
+sed -i '1i nameserver 192.168.1.250' /etc/resolv.conf
+```
+
+
+Keep in mind that all these changes will stay even on disconnection. That is just the way linux works.
+
+For this configuration to be removed, you must create another script that deletes it on disconnection:
+
+#### clientdown.sh
+```bash
+ip route del 192.168.1.0/24 via 192.168.3.1 dev vpn0
+sed -i '/^nameserver 192.168.1.250$/d' /etc/resolv.conf
+```
+
+### Telling WSVPN to execute client.sh & clientdown.sh
+Simply find these lines and edit them as follows in your `client.yml` file:
+
+```yaml
+scripts:
+  # These scripts get run as "args... operation subnet interface"
+  # Pass in an array, first argument is the executable, further arguments
+  # are used before WSVPN provided arguments
+  # Example: "./handler.sh up 192.168.3.2/24 tun0"
+  up: ["bash", "client.sh"]
+  down: ["bash", "clientdown.sh"]
+```
+
+## Final linux client directory structure
+```
+├── wsvpnclient-linux
+    ├── wsvpn-linux-amd64
+    ├── connect.sh
+    ├── client.yml
+    ├── client.sh
+    └── clientdown.sh
+```

--- a/docs/wiki/Client autoconfiguration.md
+++ b/docs/wiki/Client autoconfiguration.md
@@ -22,6 +22,8 @@ Create a batch file, here called `connect.bat`, with the following:
 cd C:\wsvpn
 wsvpn-windows-amd64.exe -mode "client" -config "client.yml"
 ```
+Replace C:\wsvpn with your folder location. This is needed as running anything as admin in windows will change path to C:\Windows\System32
+
 Then, execute it as administrator to stablish a fresh connection. 
 This should create a new `wintun.dll` file and a windows adapter that will dissapear on disconection, called `WaterWinTunInterface`.
 

--- a/docs/wiki/Setting up your server.md
+++ b/docs/wiki/Setting up your server.md
@@ -1,14 +1,52 @@
 # Setting up your server
+NOTE: I am using a linux host with systemd here.
+
 ## Creating initial files
 Create a folder for your VPN service, put the wsvpn binary in it and set up the default configuration.
-
 Make sure to get the latest binary url.
+
 ```bash
 mkdir wsvpn
 wget  https://github.com/Doridian/wsvpn/releases/download/v5.40.3/wsvpn-linux-amd64 -O wsvpn
 chmod +x wsvpn
 ./wsvpn --print-default-config -mode server > server.yml
 ```
+
+## Configuring your server
+First, configure an interface name for your VPN.
+I recommend you to leave it as `persist` in your system, as you might want to apply advanced firewall configurations in the future.
+```yaml
+name: "vpn0"
+persist: true
+```
+
+Then, configure your VPN's pool of addreses.
+```yaml
+subnet: 192.168.3.0/24
+```
+Notice that your VPN host will always take the first IP on this network. This will become your `VPN's gateway`.
+In this example, it would take 192.168.3.1.
+
+Now you need to configure your `listen ipv4 address`. This will either prevent external access without a middleman, or just allow anyone to connect to it using your IP:port.
+
+To allow everyone to access your VPN:
+```yaml
+server:
+  listen: 0.0.0.0:9000
+```
+
+To allow only an app in your host to access your VPN:
+```yaml
+server:
+  listen: 127.0.0.1:9000
+```
+
+Finally, you might want to setup some real security on your VPN.
+I recommend reading `Example: VPN with TLS and htpasswd authentication` to allow access only via a password, or `Example:-VPN-with-TLS-and-mTLS` to allow access only with a client SSL certificate.
+
+By default, your VPN will allow just anyone to access it.
+
+For further security enhancements, consider using a reverse proxy (I talk more about it at the end of this doc).
 
 ## Setting up a systemd service
 To allow your system to automatically start and stop your VPN, you must create a system service.
@@ -63,3 +101,55 @@ ExecStop=iptables -P FORWARD DROP
 WantedBy=multi-user.target
 EOF
 ```
+
+## Reverse proxy configuration
+In a real world scenario the best setup is to have a middleman handle connections for you. 
+
+Since wsvpn uses websockets, that is called a *reverse proxy*.
+
+Here I will show you an example working config for the webserver Apache2:
+
+### Apache2 reverse proxy entry (wsvpn.conf)
+```apache
+<VirtualHost *:443>
+	# SSL config
+    Include cert.conf
+	
+    ServerName wsvpn.mydomain.com
+	ServerAlias www.wsvpn.mydomain.com
+
+	# Websocket support
+	RewriteEngine On
+	RewriteCond %{HTTP:Connection} Upgrade [NC]
+	RewriteCond %{HTTP:Upgrade} websocket [NC]
+	RewriteRule /(.*) ws://localhost:9000/$1 [P,L]
+	# Proxy
+	ProxyPreserveHost on
+	ProxyPass /myprivateid/ http://localhost:9000/
+	ProxyPassReverse /myprivateid/ http://localhost:9000/
+	SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+	RequestHeader set X-Forwarded-Proto "https"
+	RequestHeader set X-Forwarded-Port "443"
+	ErrorLog ${APACHE_LOG_DIR}/wsvpn_error.log
+	CustomLog ${APACHE_LOG_DIR}/wsvpn_access.log combined
+</VirtualHost>
+<VirtualHost *:80>
+	ServerName wsvpn.mydomain.com
+	ServerAlias www.wsvpn.mydomain.com
+	RedirectPermanent / https://wsvpn.mydomain.com/
+</VirtualHost>
+```
+If you noticed I used **/myprivateid/** as a location in my webpage. This is called obfuscation.
+
+For security purposes, never expose your VPN on the root of your webpage, nor use something as common as /VPN/. Bots will find it and exploit it.
+
+In this example, clients would access my VPN via 
+wss://wsvpn.mydomain.com/myprivateid/
+
+Other ways to protect your VPN from unauthorized access are:
+- Use a fake domain name configured by the client.
+- Require certain IPs using the "require ip" statement.
+- Set up required custom http headers in both server.yml and client.yml
+- Set up htpasswd authentication.
+- Set up mutual TLS so clients require an SSL client cert to enter. 
+- Change the default listening port of your webserver to a random one

--- a/docs/wiki/Setting up your server.md
+++ b/docs/wiki/Setting up your server.md
@@ -1,0 +1,65 @@
+# Setting up your server
+## Creating initial files
+Create a folder for your VPN service, put the wsvpn binary in it and set up the default configuration.
+
+Make sure to get the latest binary url.
+```bash
+mkdir wsvpn
+wget  https://github.com/Doridian/wsvpn/releases/download/v5.40.3/wsvpn-linux-amd64 -O wsvpn
+chmod +x wsvpn
+./wsvpn --print-default-config -mode server > server.yml
+```
+
+## Setting up a systemd service
+To allow your system to automatically start and stop your VPN, you must create a system service.
+
+Here's a linux systemd service file for all of this:
+
+```bash
+cat >> /etc/systemd/system/wsvpn.service << EOF
+[Unit]
+Description=WebSocket VPN server
+After=network.target
+
+[Service]
+WorkingDirectory=/your-full-path-here/wsvpn
+Type=simple
+Restart=always
+ExecStart=/your-full-path-here/wsvpn/wsvpn -mode "server" -config "server.yml"
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+Also, you usually want to allow all VPN users to access the network via NAT (they interact with it via your system's IP). This can be accomplished by adding a few more iptables lines on your service:
+
+```bash
+cat >> /etc/systemd/system/wsvpn.service << EOF
+[Unit]
+Description=WebSocket VPN server
+After=network.target
+
+[Service]
+WorkingDirectory=/your-full-path-here/wsvpn
+Type=simple
+Restart=always
+ExecStart=/your-full-path-here/wsvpn/wsvpn -mode "server" -config "server.yml"
+
+# To allow users to interact with your network, you need to configure your system to work as a router with NAT
+# Replace 192.168.3.0/24 with your desired VPN network
+# Replace ens18 with your real interface name
+
+ExecStartPost=echo 1 > /proc/sys/net/ipv4/ip_forward
+ExecStartPost=iptables -t nat -A POSTROUTING -s 192.168.3.0/24 -o ens18 -j MASQUERADE
+ExecStop=iptables -t nat -D POSTROUTING -s 192.168.3.0/24 -o ens18 -j MASQUERADE
+
+# In the rare case that your system uses DOCKER, this is needed, as docker by default doesnt allow your system to work as a router
+ExecStartPost=iptables -P FORWARD ACCEPT
+ExecStop=iptables -P FORWARD DROP
+
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```


### PR DESCRIPTION
Hello, after using your project for a while for both working and gaming, I decided to make two little guides to help people set it up correctly, just like you would use any other VPN like wireguard.

I couldnt find any way to make pull requests to your wiki (i suppose github doesnt support it) so I put them inside a new folder called "wiki", inside your docs folder.

The first one is just how to set it up as a server in linux along with an example config for the apache reverse proxy.

The second one talks all about setting up client auto configuration, so you would just share your client files with your friends and let them join without any knowledge on networking.

On a side note, I love this project, thank you! I used it for both playing minecraft and remote access, and it works flawlessly!, just like wireguard would do. 
With some effort, im pretty sure this will someday easily surpass even wireguard, as internet traffic is always masked as "web traffic", so neither firewalls nor hackers can recognize its content, unlike any other VPN which can easily be blocked with a layer 3 firewall rule :P.